### PR TITLE
feat(community): add endpoint to fetch followed artists' communities

### DIFF
--- a/controller/search.controller.js
+++ b/controller/search.controller.js
@@ -679,11 +679,3 @@ export const searchByCategory = async (req, res) => {
     });
   }
 };
-
-// export default {
-//   searchAll,
-//   getRecentSearches,
-//   clearRecentSearches,
-//   getTrendingSearches,
-//   searchByCategory
-// };

--- a/routes/community.route.js
+++ b/routes/community.route.js
@@ -9,6 +9,7 @@ import {
   getArtistCommunitiesByGenre,
   getTrendingArtistsByGenre,
   checkIfTokenSymbolExist,
+  getFollowedArtistsCommunities,
 } from "../controller/community.controller.js";
 
 const communityRouter = Router();
@@ -27,5 +28,6 @@ communityRouter.delete("/deletecommunity/:communityId", deleteCommunity);
 // New genre-based recommendation routes
 communityRouter.get("/artists-by-genre/:userId", getArtistCommunitiesByGenre);
 communityRouter.get("/trending-artists/:userId", getTrendingArtistsByGenre);
+communityRouter.get('/followed/:userId', getFollowedArtistsCommunities);
 
 export default communityRouter;


### PR DESCRIPTION
Implement a new endpoint `/followed/:userId` to retrieve communities created by artists that the user follows. This enhances user experience by allowing them to easily access communities of their followed artists. The endpoint uses the `Follow` model to fetch followed artists and then retrieves their associated communities, including member details.