### PR TITLE
refactor: migrate from CommonJS to ES modules

### DIFF
--- a/controller/artist.controller.js
+++ b/controller/artist.controller.js
@@ -16,8 +16,8 @@ import {
   createArtistSchema,
   signContractSchema,
 } from "../validations_schemas/artist.validation.js";
-import sendEmail from "../script.cjs";
-import AbstraxionAuth from "../xion/abstraxionauth.cjs";
+import {sendEmail} from "../script.js";
+import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { ArtistClaim } from "../models/artistClaim.model.js";
 
 export const getAllArtists = async (req, res) => {

--- a/controller/artistClaim.controller.js
+++ b/controller/artistClaim.controller.js
@@ -3,7 +3,7 @@ import { User } from "../models/user.model.js";
 import { ArtistClaim } from "../models/artistClaim.model.js";
 import mongoose from "mongoose";
 import { websocketService } from '../utils/websocket/websocketServer.js';
-import sendEmail from "../script.cjs";
+import {sendEmail} from "../script.js";
 import { notificationService } from '../services/notification.service.js';
 
 export const submitArtistClaim = async (req, res) => {

--- a/controller/community.controller.js
+++ b/controller/community.controller.js
@@ -7,7 +7,7 @@ import { CommunityMember } from "../models/communitymembers.model.js";
 import { Preferences } from "../models/preferences.model.js";
 import { User } from "../models/user.model.js";
 import contractHelper from "../xion/contractConfig.js";
-import AbstraxionAuth from "../xion/abstraxionauth.cjs";
+import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { Post } from "../models/post.model.js";
 import { Follow } from "../models/followers.model.js";
 

--- a/controller/nft.controller.js
+++ b/controller/nft.controller.js
@@ -1,5 +1,5 @@
 import { User } from "../models/user.model.js";
-import AbstraxionAuth from "../xion/abstraxionauth.cjs";
+import AbstraxionAuth from "../xion/abstraxionauth.js";
 
 export const getUserNFTDetails = async (req, res) => {
   try {

--- a/controller/user.controller.js
+++ b/controller/user.controller.js
@@ -22,7 +22,7 @@ import { Genre } from "../models/genre.model.js";
 import { Community } from "../models/community.model.js";
 import { ArtistClaim } from "../models/artistClaim.model.js";
 import { CommunityMember } from "../models/communitymembers.model.js";
-import sendEmail from "../script.cjs";
+import {sendEmail} from "../script.js";
 import { generateOtp } from "../utils/helpers/generateotp.js";
 import {
   createUserSchema,
@@ -30,12 +30,12 @@ import {
 } from "../validations_schemas/auth.validation.js";
 import { validateGoogleToken } from "../middlewares/googleauth.js";
 import { validateAppleToken } from "../middlewares/appleauth.js";
-import { generateUniqueReferralCode } from "../utils/helpers/referralcode.cjs";
+import { generateUniqueReferralCode } from "../utils/helpers/referralcode.js";
 import { ReferralCode } from "../models/referralcode.model.js";
 import referralConfig from "../config/referral.config.js";
 import XionWalletService from "../xion/wallet.service.js";
 
-import AbstraxionAuth from "../xion/abstraxionauth.cjs";
+import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { Track } from "../models/track.model.js";
 import { Release } from "../models/releases.model.js";
 

--- a/controller/xion.controller.js
+++ b/controller/xion.controller.js
@@ -1,4 +1,4 @@
-import AbstraxionAuth from '../xion/abstraxionauth.cjs';
+import AbstraxionAuth from '../xion/abstraxionauth.js';
 
 export const transferFunds = async (req, res) => {
   try {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ import searchRoutes from "./routes/search.routes.js";
 import adminRouter from "./routes/admin-route/admin.route.js";
 import referralRouter from "./routes/referral.route.js";
 import oauthrouter from "./routes/oauth.route.js";
-import AbstraxionAuth from "./xion/abstraxionauth.cjs";
+import AbstraxionAuth from "./xion/abstraxionauth.js";
 import nftRoutes from "./routes/nft.routes.js";
 import xionRoutes from './routes/xion.routes.js';
 import notificationRoutes from './routes/notification.routes.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "bcryptjs": "^2.4.3",
         "buffer": "^6.0.3",
         "cors": "^2.8.5",
+        "cosmjs-types": "^0.9.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "fast-jwt": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bcryptjs": "^2.4.3",
     "buffer": "^6.0.3",
     "cors": "^2.8.5",
+    "cosmjs-types": "^0.9.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "fast-jwt": "^5.0.2",

--- a/script.js
+++ b/script.js
@@ -1,0 +1,51 @@
+import nodemailer from "nodemailer";
+import path from "path";
+import hbs from "nodemailer-express-handlebars";
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const transporter = nodemailer.createTransport({
+  host: "smtp.hostinger.com",
+  secure: true,
+  port: 465,
+  auth: {
+    user: "official@looopmusic.com",
+    pass: "Looopmusic@$12",
+  },
+  logger: true,
+  debug: true,
+});
+
+const handlebarOptions = {
+  viewEngine: {
+    extName: ".hbs",
+    partialsDir: path.resolve(__dirname, "./emails/"),
+    defaultLayout: false,
+  },
+  viewPath: path.resolve(__dirname, "./emails/"),
+  extName: ".hbs",
+};
+
+transporter.use("compile", hbs(handlebarOptions));
+
+export const sendEmail = async (to, subject, template, context) => {
+  try {
+    const mailOptions = {
+      from: `Looop Music <official@looopmusic.com>`,
+      to,
+      subject,
+      template,
+      context,
+    };
+
+    const info = await transporter.sendMail(mailOptions);
+    console.log("Email sent:", info.response);
+    return { success: true, message: "Email sent successfully!" };
+  } catch (error) {
+    console.error("Error sending email:", error);
+    return { success: false, message: error.message };
+  }
+};

--- a/utils/helpers/decryption.js
+++ b/utils/helpers/decryption.js
@@ -1,4 +1,4 @@
-const crypto = require("crypto");
+import  crypto from "crypto";
 
 const decryptPrivateKey = (backup, password) => {
   const { encryptedPrivateKey, salt, iv, tag } = backup;

--- a/utils/helpers/encryption.js
+++ b/utils/helpers/encryption.js
@@ -1,6 +1,6 @@
-const crypto = require("crypto");
+import crypto from "crypto";
 
-const encryptPrivateKey = (privateKey, password) => {
+export const encryptPrivateKey = (privateKey, password) => {
   const salt = crypto.randomBytes(16);
   const iv = crypto.randomBytes(16);
   const key = crypto.pbkdf2Sync(password, salt, 100000, 32, "sha256");
@@ -19,5 +19,3 @@ const encryptPrivateKey = (privateKey, password) => {
     tag: tag.toString("hex"),
   };
 };
-
-module.exports.encryptPrivateKey = encryptPrivateKey;

--- a/utils/helpers/encyption.js
+++ b/utils/helpers/encyption.js
@@ -1,0 +1,21 @@
+import crypto from "crypto";
+
+export const encryptPrivateKey = (privateKey, password) => {
+  const salt = crypto.randomBytes(16);
+  const iv = crypto.randomBytes(16);
+  const key = crypto.pbkdf2Sync(password, salt, 100000, 32, "sha256");
+
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(privateKey, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    encryptedPrivateKey: encrypted.toString("hex"),
+    salt: salt.toString("hex"),
+    iv: iv.toString("hex"),
+    tag: tag.toString("hex"),
+  };
+};

--- a/utils/helpers/referralcode.js
+++ b/utils/helpers/referralcode.js
@@ -1,6 +1,7 @@
-const { User } = require("../../models/user.model");
+import { User } from "../../models/user.model.js";
 
-const generateUniqueReferralCode = async (username) => {
+
+export const generateUniqueReferralCode = async (username) => {
   let isUnique = false;
   let referralCode = "";
 
@@ -20,5 +21,3 @@ const generateUniqueReferralCode = async (username) => {
 
   return referralCode;
 };
-
-module.exports = { generateUniqueReferralCode };

--- a/xion/AbstraxionAuth.js
+++ b/xion/AbstraxionAuth.js
@@ -1,27 +1,27 @@
-const {
-  GasPrice,
-  SigningStargateClient,
-  calculateFee,
-  coins,
-} = require("@cosmjs/stargate");
-const { fetchConfig } = require("@burnt-labs/constants");
-const { makeCosmoshubPath } = require("@cosmjs/amino");
-const { GranteeSignerClient } = require("./GranteeSignerClient.cjs");
-const { SignArbSecp256k1HdWallet } = require("./SignArbSecp256k1HdWallet.cjs");
-const crypto = require("crypto");
-const { Wallet } = require("../models/wallet.model.js");
-const { Bip39 } = require("@cosmjs/crypto");
-const { Registry } = require("@cosmjs/proto-signing/build");
-const { CosmWasmClient } = require("@cosmjs/cosmwasm-stargate/build");
-const { MsgGrantAllowance } = require("cosmjs-types/cosmos/feegrant/v1beta1/tx");
-const { BasicAllowance } = require("cosmjs-types/cosmos/feegrant/v1beta1/feegrant");
-const { Any } = require("cosmjs-types/google/protobuf/any");
-const { HermesClient } = require("@pythnetwork/hermes-client");
-const { RpcProvider, Contract } = require("starknet");
-const { websocketService } = require('../utils/websocket/websocketServer.js');
-const { WS_EVENTS } = require('../utils/websocket/eventTypes.js');
-const { PassSubscription } = require("../models/passSubscription.model.js");
-const Transaction = require('../models/Transaction.model.js');
+import {
+    GasPrice,
+    SigningStargateClient,
+    calculateFee,
+    coins,
+  } from "@cosmjs/stargate";
+  import { fetchConfig } from "@burnt-labs/constants";
+  import { makeCosmoshubPath } from "@cosmjs/amino";
+  import { GranteeSignerClient } from "./GranteeSignerClient.js";
+  import { SignArbSecp256k1HdWallet } from "./SignArbSecp256k1HdWallet.js";
+  import crypto from "crypto";
+  import { Wallet } from "../models/wallet.model.js";
+  import { Bip39 } from "@cosmjs/crypto";
+  import { Registry } from "@cosmjs/proto-signing";
+  import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+  import { MsgGrantAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx.js";
+  import { BasicAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/feegrant.js";
+  import { Any } from "cosmjs-types/google/protobuf/any.js";
+  import { HermesClient } from "@pythnetwork/hermes-client";
+  import { RpcProvider, Contract } from "starknet";
+  import { websocketService } from '../utils/websocket/websocketServer.js';
+  import { WS_EVENTS } from '../utils/websocket/eventTypes.js';
+  import { PassSubscription } from "../models/passSubscription.model.js";
+  import Transaction from '../models/Transaction.model.js';
 
 const USDC_ABI = [
     {
@@ -33,7 +33,7 @@ const USDC_ABI = [
     }
   ];
 
-class AbstraxionAuth {
+  export default class AbstraxionAuth  {
 
   // static instance = null;
 
@@ -69,10 +69,14 @@ class AbstraxionAuth {
     console.log("Initialized with Server Secret:", this.serverSecret);
   }
 
-  configureAbstraxionInstance(rpc, restUrl, treasury) {
-    this.rpcUrl = rpc;
-    this.restUrl = restUrl;
-    this.treasury = treasury;
+  static configureAbstraxionInstance(rpc, restUrl, treasury) {
+    if (!this.instance) {
+      this.instance = new AbstraxionAuth();
+    }
+    this.instance.rpcUrl = rpc;
+    this.instance.restUrl = restUrl;
+    this.instance.treasury = treasury;
+    return this.instance;
   }
 
   subscribeToAuthStateChange(callback) {
@@ -859,22 +863,22 @@ class AbstraxionAuth {
     } catch (error) {
       console.error("Error minting pass:", error);
 
-      // Update transaction with failed status if it exists
-      if (transaction) {
-        transaction.status = 'failed';
-        transaction.message = error.message;
-        await transaction.save();
-      }
+    //   // Update transaction with failed status if it exists
+    //   if (transaction) {
+    //     transaction.status = 'failed';
+    //     transaction.message = error.message;
+    //     await transaction.save();
+    //   }
 
-      // Notify client of failed transaction
-    if (transaction) {
-        websocketService.sendToUser(senderAddress, WS_EVENTS.TRANSACTION_UPDATE, {
-          status: 'failed',
-          transactionId: transaction._id,
-          error: error.message,
-          type: 'mint_pass'
-        });
-      }
+    //   // Notify client of failed transaction
+    // if (transaction) {
+    //     websocketService.sendToUser(senderAddress, WS_EVENTS.TRANSACTION_UPDATE, {
+    //       status: 'failed',
+    //       transactionId: transaction._id,
+    //       error: error.message,
+    //       type: 'mint_pass'
+    //     });
+    //   }
 
       throw new Error(`Failed to mint pass: ${error.message}`);
     }
@@ -1017,5 +1021,3 @@ class AbstraxionAuth {
   }
 
 }
-
-module.exports = new AbstraxionAuth();

--- a/xion/GranteeSignerClient.js
+++ b/xion/GranteeSignerClient.js
@@ -1,15 +1,9 @@
-const {
-    SigningCosmWasmClient,
-  } = require("@cosmjs/cosmwasm-stargate");
-  const {
-    calculateFee,
-    GasPrice,
-  } = require("@cosmjs/stargate");
-  const { TxRaw } = require("cosmjs-types/cosmos/tx/v1beta1/tx");
-  const { MsgExec } = require("cosmjs-types/cosmos/authz/v1beta1/tx");
-  const { Tendermint37Client } = require("@cosmjs/tendermint-rpc");
-  const { customAccountFromAny } = require("@burnt-labs/signers");
-  const { fromBech32 } = require("@cosmjs/encoding/build");
+import { calculateFee, GasPrice, SigningStargateClient } from "@cosmjs/stargate";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { MsgExec } from "cosmjs-types/cosmos/authz/v1beta1/tx.js";
+import { Tendermint37Client } from "@cosmjs/tendermint-rpc";
+import { customAccountFromAny } from "@burnt-labs/signers";
+import { fromBech32 } from "@cosmjs/encoding";
 
   function isValidBech32(address) {
     try {
@@ -20,7 +14,7 @@ const {
     }
   }
 
-  class GranteeSignerClient extends SigningCosmWasmClient {
+  export class GranteeSignerClient extends SigningStargateClient {
     constructor(cometClient, signer, options) {
       const { granterAddress, granteeAddress, gasPrice, treasuryAddress, ...restOptions } = options;
       super(cometClient, signer, { ...restOptions, gasPrice });
@@ -174,5 +168,3 @@ const {
       return super.sign(signerAddress, messages, fee, memo, explicitSignerData);
     }
   }
-
-  module.exports = { GranteeSignerClient };

--- a/xion/SignArbSecp256k1HdWallet.js
+++ b/xion/SignArbSecp256k1HdWallet.js
@@ -1,13 +1,13 @@
-const { Buffer } = require("buffer");
-const { makeSignBytes } = require("@cosmjs/proto-signing");
-const {
+import { Buffer } from "buffer";
+import { makeSignBytes, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import {
   encodeSecp256k1Signature,
   makeCosmoshubPath,
   rawSecp256k1PubkeyToRawAddress,
-} = require("@cosmjs/amino");
-const { assert, isNonNullObject } = require("@cosmjs/utils");
-const { Hash, PrivKeySecp256k1 } = require("@keplr-wallet/crypto");
-const {
+} from "@cosmjs/amino";
+import { assert, isNonNullObject } from "@cosmjs/utils";
+import { Hash, PrivKeySecp256k1 } from "@keplr-wallet/crypto";
+import {
   Argon2id,
   Bip39,
   EnglishMnemonic,
@@ -18,23 +18,22 @@ const {
   Slip10,
   Slip10Curve,
   stringToPath,
-} = require("@cosmjs/crypto");
-const {
+} from "@cosmjs/crypto";
+import {
   fromBase64,
   fromUtf8,
   toBase64,
   toBech32,
   toUtf8,
-} = require("@cosmjs/encoding");
-const { makeADR36AminoSignDoc, serializeSignDoc } = require("@keplr-wallet/cosmos");
-const {
+} from "@cosmjs/encoding";
+import { makeADR36AminoSignDoc, serializeSignDoc } from "@keplr-wallet/cosmos";
+import {
   cosmjsSalt,
   decrypt,
   encrypt,
   executeKdf,
   supportedAlgorithms,
-} = require("@cosmjs/proto-signing/build/wallet");
-const { SignDoc } = require("cosmjs-types/cosmos/tx/v1beta1/tx");
+} from "@cosmjs/proto-signing/build/wallet.js";
 
 const serializationTypeV1 = "directsecp256k1hdwallet-v1";
 
@@ -60,7 +59,7 @@ function isDerivationJson(thing) {
   return true;
 }
 
-class SignArbSecp256k1HdWallet {
+export class SignArbSecp256k1HdWallet extends DirectSecp256k1HdWallet {
   constructor(mnemonic, options) {
     const prefix = options.prefix || defaultOptions.prefix;
     const hdPaths = options.hdPaths || defaultOptions.hdPaths;
@@ -271,5 +270,3 @@ class SignArbSecp256k1HdWallet {
     ).toString("base64");
   }
 }
-
-module.exports = { SignArbSecp256k1HdWallet };


### PR DESCRIPTION
This commit refactors the codebase to use ES modules (import/export) instead of CommonJS (require/module.exports). The changes include:

- Converting .cjs files to .js
- Updating import statements in controllers and utility files
- Adding new helper files for encryption, decryption, and referral code
- Removing deprecated .cjs files
- Ensuring compatibility with modern JavaScript standards

The migration improves maintainability and aligns with current JavaScript best practices.