### PR TITLE
feat(artistClaim): add endpoint to retrieve all claims with pagination

### DIFF
--- a/controller/artist.controller.js
+++ b/controller/artist.controller.js
@@ -214,7 +214,7 @@ export const createArtist = async (req, res) => {
       isNewArtist = true;
       artist = new Artist({
         name: artistname,
-        email: user.email.toLowerCase(),
+        email: user.email,
         profileImage,
         biography: bio,
         genres,
@@ -343,6 +343,17 @@ export const signContract = async (req, res) => {
           artist: new Types.ObjectId(artist._id),
           updatedAt: new Date(),
         });
+
+        await Artist.findByIdAndUpdate(
+          artist._id,
+            {
+              verified: true,
+              verifiedAt: new Date(),
+              updatedAt: new Date(),
+              userId: user._id,
+            },
+            { session }
+          );
       }
 
       return res.status(200).json({

--- a/routes/artistClaim.route.js
+++ b/routes/artistClaim.route.js
@@ -4,6 +4,7 @@ import {
   getUserClaims,
   updateClaimStatus,
   submitArtistClaim,
+  getAllClaims,
 } from "../controller/artistClaim.controller.js";
 
 const artistClaimRouter = Router();
@@ -12,5 +13,6 @@ artistClaimRouter.post("/submit", submitArtistClaim);
 artistClaimRouter.get("/status/:claimId", getClaimStatus);
 artistClaimRouter.get("/user/:userId", getUserClaims);
 artistClaimRouter.put("/update/:claimId", updateClaimStatus);
+artistClaimRouter.get("/all", getAllClaims);
 
 export default artistClaimRouter;


### PR DESCRIPTION
Introduce a new endpoint `/all` to fetch all artist claims with pagination, filtering, and sorting options. This enhances the ability to manage and review claims more efficiently. Additionally, remove redundant verified fields from `updateClaimStatus` as they are now handled in `signContract`.