### PR TITLE
refactor: instantiate AbstraxionAuth once and reuse across controllers

### DIFF
--- a/controller/artist.controller.js
+++ b/controller/artist.controller.js
@@ -20,6 +20,8 @@ import {sendEmail} from "../script.js";
 import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { ArtistClaim } from "../models/artistClaim.model.js";
 
+const abstraxionAuth = new AbstraxionAuth();
+
 export const getAllArtists = async (req, res) => {
   try {
     const Artists = await Artist.find({});
@@ -331,8 +333,8 @@ export const signContract = async (req, res) => {
         },
       };
 
-      await AbstraxionAuth.login(user.email);
-      const sign = await AbstraxionAuth.executeSmartContract(
+      await abstraxionAuth.login(user.email);
+      const sign = await abstraxionAuth.executeSmartContract(
         "xion1wpyzctmpz605z3kyjvl9q2hccdd5v285c872d9cdlau2vhywpzrsvsgun4",
         msg,
         undefined

--- a/controller/community.controller.js
+++ b/controller/community.controller.js
@@ -11,6 +11,8 @@ import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { Post } from "../models/post.model.js";
 import { Follow } from "../models/followers.model.js";
 
+const abstraxionAuth = new AbstraxionAuth();
+
 export const getAllCommunity = async (req, res) => {
   try {
     // Find all communities and populate creator details
@@ -238,9 +240,9 @@ export const createCommunity = async (req, res) => {
             },
           };
 
-        await AbstraxionAuth.login(artist.email);
+        await abstraxionAuth.login(artist.email);
         console.log("artist email", artist.email);
-        const execute = await AbstraxionAuth.executeSmartContract(
+        const execute = await abstraxionAuth.executeSmartContract(
           "xion12s90sgu2vekmc25an5q72fvnm3jf2ncnx5xehjqd95ql2u284mxqdgykp0",
           msg,
           "auto"
@@ -259,7 +261,7 @@ export const createCommunity = async (req, res) => {
             },
           };
 
-        const getArtistCollection = await AbstraxionAuth.querySmartContract(
+        const getArtistCollection = await abstraxionAuth.querySmartContract(
             "xion12s90sgu2vekmc25an5q72fvnm3jf2ncnx5xehjqd95ql2u284mxqdgykp0",
             CollectionMsg
           );
@@ -433,9 +435,9 @@ export const joinCommunity = async (req, res) => {
     }
 
     // Login with user's email before minting
-    await AbstraxionAuth.login(user.email);
+    await abstraxionAuth.login(user.email);
 
-    const mint = await AbstraxionAuth.mintPass(
+    const mint = await abstraxionAuth.mintPass(
       community.tribePass.contractAddress,
     );
 

--- a/controller/nft.controller.js
+++ b/controller/nft.controller.js
@@ -1,6 +1,9 @@
 import { User } from "../models/user.model.js";
 import AbstraxionAuth from "../xion/abstraxionauth.js";
 
+const abstraxionAuth = new AbstraxionAuth();
+
+// Controller to get NFT details for a user
 export const getUserNFTDetails = async (req, res) => {
   try {
     const { userId } = req.params;
@@ -29,7 +32,7 @@ export const getUserNFTDetails = async (req, res) => {
     }
 
     // Get NFT details using AbstraxionAuth
-    const nftDetails = await AbstraxionAuth.getNFTDetailsByContracts(contractAddresses);
+    const nftDetails = await abstraxionAuth.getNFTDetailsByContracts(contractAddresses);
 
     // Combine NFT details with community information
     const enrichedNFTDetails = nftDetails.data.map(nftDetail => {

--- a/controller/user.controller.js
+++ b/controller/user.controller.js
@@ -39,6 +39,8 @@ import AbstraxionAuth from "../xion/abstraxionauth.js";
 import { Track } from "../models/track.model.js";
 import { Release } from "../models/releases.model.js";
 
+const abstraxionAuth = new AbstraxionAuth();
+
 // Loads .env
 config();
 
@@ -304,7 +306,7 @@ const createUser = async (req, res) => {
     };
 
     const tokenbound = new TokenboundClient(options);
-    const xionwallet = await AbstraxionAuth.signup(email);
+    const xionwallet = await abstraxionAuth.signup(email);
 
     const refcode = await generateUniqueReferralCode(username);
 
@@ -466,6 +468,7 @@ const createUser = async (req, res) => {
     });
   }
 };
+
 const verifyOtp = async (req, res) => {
     const { email, otp } = req.body;
 
@@ -1192,7 +1195,7 @@ const verifyOtp = async (req, res) => {
             }
           ]);
 
-          const xionLoggedInUser = await AbstraxionAuth.login(email);
+          const xionLoggedInUser = await abstraxionAuth.login(email);
 
           if (xionLoggedInUser) {
             const userData = {
@@ -2056,7 +2059,7 @@ const verifyOtp = async (req, res) => {
         }
 
         // Get both XION and StarkNet balances using AbstraxionAuth
-        const balanceData = await AbstraxionAuth.getBalances(xionAddress, undefined, starknetAddress);
+        const balanceData = await abstraxionAuth.getBalances(xionAddress, undefined, starknetAddress);
 
         return res.status(200).json({
           status: "success",

--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ import xionRoutes from './routes/xion.routes.js';
 import notificationRoutes from './routes/notification.routes.js';
 import AbstraxionAuth from './xion/abstraxionauth.js';
 
+const abstraxionAuth = new AbstraxionAuth();
+
 config();
 
 const app = express();


### PR DESCRIPTION
This change creates a single instance of the AbstraxionAuth class and reuses it across multiple controllers. This improves code maintainability by reducing redundancy and ensuring consistent usage of the AbstraxionAuth functionality.